### PR TITLE
systemui: animate clear recents exit

### DIFF
--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -189,7 +189,7 @@
     <integer name="recents_nav_bar_scrim_enter_duration">400</integer>
 
     <!-- The animation duration for animating the removal of a task view. -->
-    <integer name="recents_animate_task_view_remove_duration">250</integer>
+    <integer name="recents_animate_task_view_remove_duration">450</integer>
 
     <!-- The animation duration for scrolling the stack to a particular item. -->
     <integer name="recents_animate_task_stack_scroll_duration">225</integer>


### PR DESCRIPTION
Currently, the animation just clear all the tasks at the same time. Just add
a delay between every task remove call, and hide clear recents before start
any animation.

PureNexus edits:
Forward ported to marshmallow, removed googles clear all animation that was conflicting with ours

Change-Id: Ic652263ba50b27ec6b800558eb661f6e8d624d6f
